### PR TITLE
Add conversion from Coinbase CSV format

### DIFF
--- a/convert/accointing/Coinbase.md
+++ b/convert/accointing/Coinbase.md
@@ -1,0 +1,15 @@
+# Coinbase #
+
+**IMPORTANT NOTE:**  Coinbase conversion is considered experimental.  Check converted transactions carefully.
+**IMPORTANT NOTE:**  The current implementation is limited to the US region, specified as 'us'.
+
+Unlike other input sources, I have not done a full comparison of Accointing's handling of Coinbase via API versus
+Coinbase via converted CSV.  Rather, the conversion from a CSV exported from Coinbase to the Accointing template CSV
+format was done simply for consistency.
+
+As with other input formats, my use of Coinbase was limited in the types of transactions, so the `to-accointing.py`
+script may not handle all cases, may handle some cases incorrectly, or may simply throw an error.  Check converted
+transactions carefully.
+
+
+[Back](TO-ACCOINTING.md)

--- a/convert/accointing/TO-ACCOINTING.md
+++ b/convert/accointing/TO-ACCOINTING.md
@@ -97,6 +97,7 @@ information:
 * [Binance.US](BinanceUS.md)
 * [BlockFi](BlockFi.md)
 * [Celsius](Celsius.md)
+* [Coinbase](Coinbase.md) **NOTE:** Support for Coinbase is experimental!
 * [TradeStation](TradeStation.md)
 
 


### PR DESCRIPTION
Adds *experimental* support for converting CSV files exported from Coinbase to the Accointing CSV template format.  Only region 'us' is supported.